### PR TITLE
Made SAR_Generator::query_manipulation() static

### DIFF
--- a/generator.php
+++ b/generator.php
@@ -42,7 +42,7 @@ class SAR_Generator {
 		return true;
 	}
 
-	function query_manipulation( $bits, $wp_query ) {
+	public static function query_manipulation( $bits, $wp_query ) {
 		if ( $wp_query->get( 'months_with_posts' ) ) {
 			$bits['fields'] = 'DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month';
 			$bits['orderby'] = 'year DESC, month ASC';


### PR DESCRIPTION
Method is hooked to filter statically and lack of explicit static keyword throws PHP Strict Standards notice on call.
